### PR TITLE
Update puppet module for 1password

### DIFF
--- a/lib/puppet/functions/generate_password.rb
+++ b/lib/puppet/functions/generate_password.rb
@@ -8,8 +8,7 @@ Puppet::Functions.create_function(:'generate_password') do
     else
       pwlen = 10
     end
-    pass = rand.to_s  + $$.to_s + Time.now.to_s 
-    pass.crypt(Time.now.sec.to_s*2)[-pwlen,pwlen]
+    SecureRandom.alphanumeric(length)
   end
 end
 

--- a/lib/puppet/functions/op/hiera.rb
+++ b/lib/puppet/functions/op/hiera.rb
@@ -47,7 +47,7 @@ Puppet::Functions.create_function(:'op::hiera') do
   def lookup_key(secret_name, options, context)
     msg = ''
     # This is a reserved key name in hiera
-    return context.not_found if secret_name == 'lookup_options'
+    context.not_found if secret_name == 'lookup_options'
 
     # Verify keybase is set and skip others
     key_base = options['keybase']
@@ -67,6 +67,12 @@ Puppet::Functions.create_function(:'op::hiera') do
     end
 
     # Determine secret_key, splitting by ::
+    if options['exact'].nil?
+      exact = true
+    else
+      exact = options['exact']
+    end
+    create = false
     keyarr = secret_name.split(/::/, -1)
     if keyarr.length < 2 
       context.explain { "OP: Secret name #{secret_name} must match #{key_base}::[vaultname::]secretname[::exact]" }
@@ -76,23 +82,26 @@ Puppet::Functions.create_function(:'op::hiera') do
     end
     if keyarr.length < 3
       vault = options['vault']
-      secret_title = keyarr[1]
+      secret_title = context.interpolate(keyarr[1])
     else
       if keyarr[1] == '*'
         vault = nil
       else
         vault = keyarr[1]
       end 
-      secret_title = keyarr[2]
+      secret_title = context.interpolate(keyarr[2])
       if keyarr.length > 3
         if keyarr[3] == 'false'
           exact = false
         elsif keyarr[3] == 'true'
           exact = true
+        elsif keyarr[3] == 'create'
+          exact = true
+          create = true
         else
-          context.explain { "OP: Secret name #{secret_name} final option can only be true or false" }
+          context.explain { "OP: Secret name #{secret_name} final option can only be true, false, or create" }
           return "BAD-FORMAT-IDENTIFIER"
-          raise ArgumentError, "OP: Secret name #{secret_name} final option can only be true or false"
+          raise ArgumentError, "OP: Secret name #{secret_name} final option can only be true, false, or create"
         end
       end
     end
@@ -103,11 +112,6 @@ Puppet::Functions.create_function(:'op::hiera') do
     end
 
     # Search
-    if options['exact'].nil?
-      exact = true
-    else
-      exact = options['exact']
-    end
     # Obtain a onepassword object
     op = Puppet::Util::OnePassword.op_connect(options['apikey'],options['endpoint'])
     if op.nil? 
@@ -180,8 +184,70 @@ Puppet::Functions.create_function(:'op::hiera') do
 
     # not found
     if secretvalue.nil?
-      context.explain { "OP: Unable to find secret #{secret_title} in vault #{vault}#{msg}" }
-      context.not_found
+      if create
+        # create the secret and return it
+        secretvalue = rand.to_s  + $$.to_s + Time.now.to_s 
+        secretvalue.crypt(Time.now.sec.to_s*2)[-16,16]
+
+        vault = Puppet::Util::OnePassword.op_default_vault() if vault.nil?
+        vaultid = nil
+        op.vaults.each { |v|
+          if v.name == vault
+            vaultid = v.id
+          end
+        }
+
+        if vaultid.nil?
+          Puppet.send_log(:err,"OP: Cannot identify vault '#{vault}'")
+          context.not_found
+        end
+         
+        # Identify username, if we can
+        username = secret_name.sub( /@.*/, "" ).sub( /^.*:\/*/, "" )
+
+        # Create the item
+        begin
+          item = op.create_item(vault_id: vaultid, 
+            category: 'LOGIN', tags: [ 'puppet' ],
+            title: secret_name,
+            fields: [
+              {
+                id: "username",
+                purpose: "USERNAME",
+                value: username,
+              },
+              {
+                id: "password",
+                purpose: "PASSWORD",
+                value: secretvalue,
+              },
+              {
+                id: "notesPlain",
+                purpose: "NOTES",
+                value: "Created by puppet module"
+              }
+            ]
+          )
+        rescue => error
+          Puppet.send_log(:err, "OP: Failed to create item #{secretname} - #{error.message}" )
+          raise ArgumentError, "OP: Unable to create new item in vault #{vault}"
+          context.not_found
+        end
+        if item.nil?
+          Puppet.send_log(:err, "OP: Failed to create item #{secretname} in #{vault}" )
+          raise( "unknown: 1Password item create ERROR for #{secretname} in #{vault}" )
+          context.not_found
+        else
+          Puppet.send_log(:info, "OP: Created new secret #{secretname}" )
+          context.explain { "OP: Created new #{secret_title} #{msg}" }
+          return context.cache(secret_name, secretvalue)
+        end
+
+      else
+        # error out
+        context.explain { "OP: Unable to find secret #{secret_title} in vault #{vault}#{msg}" }
+        context.not_found
+      end
     end
 
     # Return the secret, and cache it for next time

--- a/lib/puppet/functions/op/hiera.rb
+++ b/lib/puppet/functions/op/hiera.rb
@@ -230,12 +230,12 @@ Puppet::Functions.create_function(:'op::hiera') do
           )
         rescue => error
           Puppet.send_log(:err, "OP: Failed to create item #{secretname} - #{error.message}" )
-          raise ArgumentError, "OP: Unable to create new item in vault #{vault}"
+          raise Puppet::Error, "OP: Unable to create new item in vault #{vault}"
           context.not_found
         end
         if item.nil?
           Puppet.send_log(:err, "OP: Failed to create item #{secretname} in #{vault}" )
-          raise( "unknown: 1Password item create ERROR for #{secretname} in #{vault}" )
+          raise Puppet::Error, "OP: 1Password item create ERROR for #{secretname} in #{vault}" 
           context.not_found
         else
           Puppet.send_log(:info, "OP: Created new secret #{secretname}" )

--- a/lookuptest.sh
+++ b/lookuptest.sh
@@ -9,6 +9,8 @@
 # %{lookup('onepassword::Playpen::sjs@test1')}
 # %{lookup('onepassword::*::sjs@test1')}
 # %{lookup('onepassword::Playpen::fuzzy match::false')}
+# %{lookup('onepassword::Playpen::newkey::create')}
+# %{lookup('onepassword::Playpen::newkey-%{::site}::create')}
 
 DEBUG=--debug
 DEBUG=
@@ -17,22 +19,22 @@ TESTROLE=core_inf
 TESTSITE=xmt
 TESTHOST=${TESTSITE}inf01
 TESTKEY=""
-BASE=$HOME/.puppetlabs
+BASE=$HOME/.puppet
 if [ ! -d $BASE ]; then
   BASE=/etc/puppetlabs
 fi
-ENVDIR=$BASE/etc/code/environments
+ENVDIR=$BASE/code/environments
 ENVIRONMENT=test
 HIERAFILE=$ENVDIR/$ENVIRONMENT/hiera.yaml
 MODDIR=$ENVDIR/$ENVIRONMENT/modules
 PKCSPUB=$HOME/config/puppet-public.pem
 PKCSPVT=$HOME/config/puppet-private.pem
 LIBCACHEDIR=/opt/puppetlabs/puppet/cache
-OPCONFIG=$BASE/etc/puppet/1password.yaml
+OPCONFIG=$BASE/etc/1password.yaml
 
 FACTS=/tmp/facts.$$
-PUPPET=/opt/puppetlabs/puppet/bin/puppet
-GEM=/opt/puppetlabs/puppet/bin/gem
+PUPPET=/usr/bin/puppet
+GEM=gem
 
 makefacts()
 {
@@ -165,8 +167,12 @@ if [ "$TESTKEY" == "" ]; then
  'onepassword::Playpen::sjs@test1' \
  'onepassword::sjs@test1' \
  'onepassword::*::sjs@test1' \
- 'onepassword::Playpen::fuzzy match::false' \
- 'testkeya' 'testkeyb' 
+ 'onepassword::Playpen::fuzzy::false' \
+ 'onepassword::Playpen::fuzzy::true' \
+ 'testkeya' 'testkeyb'  \
+ 'onepassword::Playpen::donotcreate' \
+ 'onepassword::Playpen::create::create' \
+ 'onepassword::Playpen::createinterpolated-%{::site}::create' \
  "
 else
   KEYLIST="'$TESTKEY'"
@@ -185,7 +191,7 @@ $PUPPET lookup $DEBUG --environment "$ENVIRONMENT" \
 rv=$?
 if [ $rv -ne 0 ]; then
   echo "EXIT STATUS: $rv"
-  exit 1
+#  exit 1
 fi
 
 done


### PR DESCRIPTION
* Add option to create item with random password if it does not exist (suffix: `::create` )
* Process embedded interpolations ( so that you can use `%{lookup('op::Vault::user@%{::site}.smxemail.com')}` )
* Allow exact-match suffix `::true` to override global defaults
* Use better secure-create password function for random passwords